### PR TITLE
pod installでのエラーを解消する為の修正です。

### DIFF
--- a/ios/RNSkyWay.podspec
+++ b/ios/RNSkyWay.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNSkyWay
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://webrtc.ecl.ntt.com/"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }

--- a/ios/RNSkyWay.podspec
+++ b/ios/RNSkyWay.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNSkyWay.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/tsukushi0104/react-native-skyway.git", :tag => "master" }
   s.source_files  = "RNSkyWay/**/*.{h,m}"
   s.requires_arc = true
 


### PR DESCRIPTION
このエラーを消すための修正です。
```
[!] The `RNSkyWay` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```